### PR TITLE
fix: 修复本地代理(Clash/Surge)测速失败问题

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -336,7 +336,7 @@ function generateXrayConfig(mainProxyStr, localPort, preProxyConfig = null) {
         inbounds: [{ port: localPort, listen: "127.0.0.1", protocol: "socks", settings: { udp: true } }],
         outbounds: outbounds,
         routing: {
-            domainStrategy: "IPIfNonMatch",
+            domainStrategy: "AsIs",
             rules: [{ type: "field", outboundTag: "proxy_main", port: "0-65535" }]
         }
     };


### PR DESCRIPTION
问题分析:
- 当用户配置本地 SOCKS5 代理(如 socks5://127.0.0.1:1081)时,测速失败
- 原因是 Xray 使用 IPIfNonMatch 策略,会尝试在本地进行 DNS 解析
- 如果用户使用 Clash 等开启了 fake-ip 模式,本地 DNS 解析会失败或返回无效 IP

解决方案:
- 将 domainStrategy 从 'IPIfNonMatch' 改为 'AsIs'
- 'AsIs' 不在本地解析域名,而是将域名原样传递给代理服务器处理
- 这等同于 socks5h:// 的行为,让代理服务器负责 DNS 解析

影响评估:
- 对于本地 SOCKS/HTTP 代理: 域名由 Clash/Surge 解析,完全兼容
- 对于远程 VMess/VLESS/Trojan: Xray 在 Outbound 层处理 DNS,不受影响
- 由于 GeekezBrowser 不使用 IP-CIDR 分流规则,此改动无副作用