### PR TITLE
Fix Linux startup and runtime issues for Chromium and Xray

### DIFF
--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -10,7 +10,8 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/main/index.js'),
           'chromium-path': resolve(__dirname, 'src/main/chromium-path.js'),
-          'close-behavior': resolve(__dirname, 'src/main/close-behavior.js')
+          'close-behavior': resolve(__dirname, 'src/main/close-behavior.js'),
+          'xray-assets': resolve(__dirname, 'src/main/xray-assets.js')
         }
       }
     }

--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -9,7 +9,8 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(__dirname, 'src/main/index.js'),
-          'chromium-path': resolve(__dirname, 'src/main/chromium-path.js')
+          'chromium-path': resolve(__dirname, 'src/main/chromium-path.js'),
+          'close-behavior': resolve(__dirname, 'src/main/close-behavior.js')
         }
       }
     }

--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -8,7 +8,8 @@ export default defineConfig({
     build: {
       rollupOptions: {
         input: {
-          index: resolve(__dirname, 'src/main/index.js')
+          index: resolve(__dirname, 'src/main/index.js'),
+          'chromium-path': resolve(__dirname, 'src/main/chromium-path.js')
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "EchoHS",
   "scripts": {
     "dev": "electron-vite dev",
-    "test": "node --test tests/chromium-path.test.js",
+    "test": "node --test tests/*.test.js",
     "build": "electron-vite build",
     "postinstall": "node setup.js",
     "build:win": "npm run build && electron-builder --win",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "EchoHS",
   "scripts": {
     "dev": "electron-vite dev",
+    "test": "node --test tests/chromium-path.test.js",
     "build": "electron-vite build",
     "postinstall": "node setup.js",
     "build:win": "npm run build && electron-builder --win",

--- a/setup.js
+++ b/setup.js
@@ -4,6 +4,7 @@ const https = require('https');
 const os = require('os');
 const { exec } = require('child_process');
 const readline = require('readline'); // 引入 readline 用于控制光标
+const { resolveXrayAssetName } = require('./src/main/xray-assets');
 
 // 配置
 const RESOURCES_BIN = path.join(__dirname, 'resources', 'bin');
@@ -50,20 +51,18 @@ function showProgress(received, total, startTime, prefix = 'Downloading') {
 function getPlatformInfo() {
     const platform = os.platform();
     const arch = os.arch();
-    let xrayAsset = '';
     let exeName = 'xray';
+    const xrayAsset = resolveXrayAssetName({ platform, arch });
 
-    if (platform === 'win32') {
-        xrayAsset = `Xray-windows-${arch === 'x64' ? '64' : '32'}.zip`;
-        exeName = 'xray.exe';
-    } else if (platform === 'darwin') {
-        xrayAsset = `Xray-macos-${arch === 'arm64' ? 'arm64-v8a' : '64'}.zip`;
-    } else if (platform === 'linux') {
-        xrayAsset = `Xray-linux-${arch === 'x64' ? '64' : '32'}.zip`;
-    } else {
-        console.error('❌ Unsupported Platform:', platform);
+    if (!xrayAsset) {
+        console.error('❌ Unsupported Platform/Arch:', `${platform}-${arch}`);
         process.exit(1);
     }
+
+    if (platform === 'win32') {
+        exeName = 'xray.exe';
+    }
+
     return { xrayAsset, exeName };
 }
 

--- a/src/main/chromium-path.js
+++ b/src/main/chromium-path.js
@@ -1,0 +1,168 @@
+const fs = require('fs');
+const path = require('path');
+
+const BUNDLED_BASENAMES = {
+    darwin: ['Google Chrome for Testing'],
+    linux: ['chrome', 'google-chrome', 'chromium', 'chromium-browser'],
+    win32: ['chrome.exe']
+};
+
+const PATH_CANDIDATES = {
+    darwin: ['Google Chrome for Testing', 'Google Chrome'],
+    linux: ['google-chrome-stable', 'google-chrome', 'chromium-browser', 'chromium', 'chrome'],
+    win32: ['chrome.exe', 'chrome']
+};
+
+function isExecutableFile(filePath, platform = process.platform) {
+    if (!filePath) return false;
+    try {
+        const stat = fs.statSync(filePath);
+        if (!stat.isFile()) return false;
+        if (platform === 'win32') return true;
+        fs.accessSync(filePath, fs.constants.X_OK);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function scoreBundledCandidate(filePath, platform = process.platform) {
+    const normalized = filePath.toLowerCase();
+    let score = 0;
+
+    if (platform === 'darwin') {
+        if (filePath.endsWith(path.join('Contents', 'MacOS', 'Google Chrome for Testing'))) score += 200;
+        if (normalized.includes('google chrome for testing.app')) score += 100;
+    } else if (platform === 'linux') {
+        if (path.basename(filePath) === 'chrome') score += 200;
+        if (normalized.includes('chrome-linux')) score += 100;
+        if (normalized.includes('chrome-for-testing')) score += 50;
+    } else if (platform === 'win32') {
+        if (path.basename(filePath).toLowerCase() === 'chrome.exe') score += 200;
+        if (normalized.includes('chrome-win')) score += 100;
+    }
+
+    return score;
+}
+
+function findBundledChromiumPath(basePath, platform = process.platform) {
+    if (!basePath || !fs.existsSync(basePath)) return null;
+
+    const basenames = new Set(BUNDLED_BASENAMES[platform] || []);
+    let bestMatch = null;
+
+    function walk(dir, depth = 0) {
+        if (depth > 8) return;
+
+        let entries = [];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch (error) {
+            return;
+        }
+
+        for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                walk(fullPath, depth + 1);
+                continue;
+            }
+
+            if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+            if (!basenames.has(entry.name)) continue;
+            if (!isExecutableFile(fullPath, platform)) continue;
+
+            const score = scoreBundledCandidate(fullPath, platform);
+            if (!bestMatch || score > bestMatch.score || (score === bestMatch.score && fullPath.length < bestMatch.path.length)) {
+                bestMatch = { path: fullPath, score };
+            }
+        }
+    }
+
+    walk(basePath);
+    return bestMatch ? bestMatch.path : null;
+}
+
+function findExecutableInPath(names, platform = process.platform, env = process.env) {
+    const pathEntries = String(env.PATH || '')
+        .split(path.delimiter)
+        .filter(Boolean);
+
+    for (const name of names) {
+        for (const dir of pathEntries) {
+            const fullPath = path.join(dir, name);
+            if (isExecutableFile(fullPath, platform)) return fullPath;
+            if (platform === 'win32' && !name.toLowerCase().endsWith('.exe') && isExecutableFile(`${fullPath}.exe`, platform)) {
+                return `${fullPath}.exe`;
+            }
+        }
+    }
+
+    return null;
+}
+
+function listExplicitChromiumCandidates(env = process.env) {
+    return [env.CHROME_PATH, env.CHROMIUM_PATH].filter(Boolean);
+}
+
+function listStandardChromiumCandidates(platform = process.platform, env = process.env) {
+    const homeDir = env.HOME || env.USERPROFILE || '';
+
+    if (platform === 'darwin') {
+        return [
+            '/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+            '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+            homeDir ? path.join(homeDir, 'Applications', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing') : null,
+            homeDir ? path.join(homeDir, 'Applications', 'Google Chrome.app', 'Contents', 'MacOS', 'Google Chrome') : null
+        ].filter(Boolean);
+    }
+
+    if (platform === 'win32') {
+        const localAppData = env.LOCALAPPDATA || '';
+        const programFiles = env.PROGRAMFILES || 'C:\\Program Files';
+        const programFilesX86 = env['PROGRAMFILES(X86)'] || 'C:\\Program Files (x86)';
+        return [
+            localAppData ? path.join(localAppData, 'Google', 'Chrome', 'Application', 'chrome.exe') : null,
+            path.join(programFiles, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+            path.join(programFilesX86, 'Google', 'Chrome', 'Application', 'chrome.exe')
+        ].filter(Boolean);
+    }
+
+    return [
+        '/opt/google/chrome/chrome',
+        '/usr/bin/google-chrome-stable',
+        '/usr/bin/google-chrome',
+        '/usr/bin/chromium-browser',
+        '/usr/bin/chromium',
+        '/snap/bin/chromium'
+    ].filter(Boolean);
+}
+
+function resolveChromiumPath({ basePath, platform = process.platform, env = process.env } = {}) {
+    const bundledPath = findBundledChromiumPath(basePath, platform);
+    if (bundledPath) return bundledPath;
+
+    for (const candidate of listExplicitChromiumCandidates(env)) {
+        if (isExecutableFile(candidate, platform)) return candidate;
+    }
+
+    const pathCandidate = findExecutableInPath(PATH_CANDIDATES[platform] || [], platform, env);
+    if (pathCandidate) return pathCandidate;
+
+    for (const candidate of listStandardChromiumCandidates(platform, env)) {
+        if (isExecutableFile(candidate, platform)) return candidate;
+    }
+
+    return null;
+}
+
+function getChromiumPath({ isDev, appPath, resourcesPath, platform = process.platform, env = process.env } = {}) {
+    const basePath = isDev ? path.join(appPath, 'resources', 'puppeteer') : path.join(resourcesPath, 'puppeteer');
+    return resolveChromiumPath({ basePath, platform, env });
+}
+
+module.exports = {
+    getChromiumPath,
+    resolveChromiumPath
+};

--- a/src/main/close-behavior.js
+++ b/src/main/close-behavior.js
@@ -1,0 +1,22 @@
+const CLOSE_BEHAVIOR = {
+    TRAY: 'tray',
+    QUIT: 'quit'
+};
+
+function normalizeCloseBehavior(rawValue) {
+    return rawValue === CLOSE_BEHAVIOR.QUIT ? CLOSE_BEHAVIOR.QUIT : CLOSE_BEHAVIOR.TRAY;
+}
+
+function resolveCloseBehavior(rawValue, { trayAvailable = true } = {}) {
+    const preferredBehavior = normalizeCloseBehavior(rawValue);
+    if (preferredBehavior === CLOSE_BEHAVIOR.TRAY && !trayAvailable) {
+        return CLOSE_BEHAVIOR.QUIT;
+    }
+    return preferredBehavior;
+}
+
+module.exports = {
+    CLOSE_BEHAVIOR,
+    normalizeCloseBehavior,
+    resolveCloseBehavior
+};

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -14,6 +14,7 @@ const zlib = require('zlib');
 const { promisify } = require('util');
 const { getChromiumPath: resolveChromiumPathForApp } = require('./chromium-path');
 const { CLOSE_BEHAVIOR, normalizeCloseBehavior, resolveCloseBehavior } = require('./close-behavior');
+const { resolveXrayAssetName } = require('./xray-assets');
 const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 const initSqlJs = require('sql.js');
@@ -2701,7 +2702,7 @@ ipcMain.handle('test-proxy-latency-batch', async (_e, entries) => {
 });
 ipcMain.handle('set-title-bar-color', (e, colors) => { const win = BrowserWindow.fromWebContents(e.sender); if (win) { if (process.platform === 'win32') try { win.setTitleBarOverlay({ color: colors.bg, symbolColor: colors.symbol }); } catch (e) { } win.setBackgroundColor(colors.bg); } });
 ipcMain.handle('check-app-update', async () => { try { const data = await fetchJson('https://api.github.com/repos/EchoHS/GeekezBrowser/releases/latest'); if (!data || !data.tag_name) return { update: false }; const remote = data.tag_name.replace('v', ''); if (compareVersions(remote, app.getVersion()) > 0) { return { update: true, remote, url: 'https://browser.geekez.net/#downloads', notes: data.body }; } return { update: false }; } catch (e) { return { update: false, error: e.message }; } });
-ipcMain.handle('check-xray-update', async () => { try { const data = await fetchJson('https://api.github.com/repos/XTLS/Xray-core/releases/latest'); if (!data || !data.tag_name) return { update: false }; const remoteVer = data.tag_name; const currentVer = await getLocalXrayVersion(); if (remoteVer !== currentVer) { let assetName = ''; const arch = os.arch(); const platform = os.platform(); if (platform === 'win32') assetName = `Xray-windows-${arch === 'x64' ? '64' : '32'}.zip`; else if (platform === 'darwin') assetName = `Xray-macos-${arch === 'arm64' ? 'arm64-v8a' : '64'}.zip`; else assetName = `Xray-linux-${arch === 'x64' ? '64' : '32'}.zip`; const downloadUrl = `https://gh-proxy.com/https://github.com/XTLS/Xray-core/releases/download/${remoteVer}/${assetName}`; return { update: true, remote: remoteVer.replace(/^v/, ''), downloadUrl }; } return { update: false }; } catch (e) { return { update: false }; } });
+ipcMain.handle('check-xray-update', async () => { try { const data = await fetchJson('https://api.github.com/repos/XTLS/Xray-core/releases/latest'); if (!data || !data.tag_name) return { update: false }; const remoteVer = data.tag_name; const currentVer = await getLocalXrayVersion(); if (remoteVer !== currentVer) { const assetName = resolveXrayAssetName({ platform: os.platform(), arch: os.arch() }); if (!assetName) return { update: false, error: `Unsupported platform/arch: ${os.platform()}-${os.arch()}` }; const downloadUrl = `https://gh-proxy.com/https://github.com/XTLS/Xray-core/releases/download/${remoteVer}/${assetName}`; return { update: true, remote: remoteVer.replace(/^v/, ''), downloadUrl }; } return { update: false }; } catch (e) { return { update: false }; } });
 ipcMain.handle('download-xray-update', async (e, url) => {
     const exeName = process.platform === 'win32' ? 'xray.exe' : 'xray';
     const tempBase = os.tmpdir();

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -13,6 +13,7 @@ const crypto = require('crypto');
 const zlib = require('zlib');
 const { promisify } = require('util');
 const { getChromiumPath: resolveChromiumPathForApp } = require('./chromium-path');
+const { CLOSE_BEHAVIOR, normalizeCloseBehavior, resolveCloseBehavior } = require('./close-behavior');
 const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 const initSqlJs = require('sql.js');
@@ -149,11 +150,6 @@ let apiServerRunning = false;
 let mainWindow = null; // Global reference for API-to-UI communication
 let appTray = null;
 let isAppQuitting = false;
-
-const CLOSE_BEHAVIOR = {
-    TRAY: 'tray',
-    QUIT: 'quit'
-};
 let cachedCloseBehavior = CLOSE_BEHAVIOR.TRAY;
 
 // ============================================================================
@@ -296,10 +292,6 @@ function normalizeTags(rawTags) {
             .filter(Boolean);
     }
     return [];
-}
-
-function normalizeCloseBehavior(rawValue) {
-    return rawValue === CLOSE_BEHAVIOR.QUIT ? CLOSE_BEHAVIOR.QUIT : CLOSE_BEHAVIOR.TRAY;
 }
 
 function sanitizeExtensionStoreId(rawId) {
@@ -1593,6 +1585,10 @@ function getCloseBehavior() {
     return normalizeCloseBehavior(cachedCloseBehavior);
 }
 
+function isTrayAvailable() {
+    return !!appTray && (typeof appTray.isDestroyed !== 'function' || !appTray.isDestroyed());
+}
+
 function showMainWindow() {
     if (!mainWindow || mainWindow.isDestroyed()) {
         createWindow();
@@ -1972,7 +1968,11 @@ function createWindow() {
     win.on('close', (event) => {
         if (isAppQuitting) return;
 
-        if (getCloseBehavior() === CLOSE_BEHAVIOR.QUIT) {
+        const effectiveCloseBehavior = resolveCloseBehavior(getCloseBehavior(), {
+            trayAvailable: isTrayAvailable()
+        });
+
+        if (effectiveCloseBehavior === CLOSE_BEHAVIOR.QUIT) {
             event.preventDefault();
             quitApplication();
             return;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -12,6 +12,7 @@ const os = require('os');
 const crypto = require('crypto');
 const zlib = require('zlib');
 const { promisify } = require('util');
+const { getChromiumPath: resolveChromiumPathForApp } = require('./chromium-path');
 const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 const initSqlJs = require('sql.js');
@@ -1541,26 +1542,13 @@ function forceKill(pid) {
 }
 
 function getChromiumPath() {
-    const basePath = isDev ? path.join(app.getAppPath(), 'resources', 'puppeteer') : path.join(process.resourcesPath, 'puppeteer');
-    if (!fs.existsSync(basePath)) return null;
-    function findFile(dir, filename) {
-        try {
-            const files = fs.readdirSync(dir);
-            for (const file of files) {
-                const fullPath = path.join(dir, file);
-                const stat = fs.statSync(fullPath);
-                if (stat.isDirectory()) { const res = findFile(fullPath, filename); if (res) return res; }
-                else if (file === filename) return fullPath;
-            }
-        } catch (e) { return null; } return null;
-    }
-
-    // macOS: Chrome binary is inside .app/Contents/MacOS/
-    if (process.platform === 'darwin') {
-        return findFile(basePath, 'Google Chrome for Testing');
-    }
-    // Windows
-    return findFile(basePath, 'chrome.exe');
+    return resolveChromiumPathForApp({
+        isDev,
+        appPath: app.getAppPath(),
+        resourcesPath: process.resourcesPath,
+        platform: process.platform,
+        env: process.env
+    });
 }
 
 // Settings management

--- a/src/main/xray-assets.js
+++ b/src/main/xray-assets.js
@@ -1,0 +1,47 @@
+function parseArmVersion(value) {
+    const parsed = Number.parseInt(String(value || ''), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function detectArmVersion({ env = process.env, processConfig = process.config } = {}) {
+    return parseArmVersion(
+        env.npm_config_arm_version ||
+        env.NPM_CONFIG_ARM_VERSION ||
+        processConfig?.variables?.arm_version
+    );
+}
+
+function resolveLinuxXrayAssetName({ arch, armVersion = detectArmVersion() } = {}) {
+    if (arch === 'x64') return 'Xray-linux-64.zip';
+    if (arch === 'ia32') return 'Xray-linux-32.zip';
+    if (arch === 'arm64') return 'Xray-linux-arm64-v8a.zip';
+    if (arch !== 'arm') return null;
+
+    if (armVersion === 5) return 'Xray-linux-arm32-v5.zip';
+    if (armVersion === 6) return 'Xray-linux-arm32-v6.zip';
+
+    // Default to v7a when the exact ARM variant is unavailable.
+    return 'Xray-linux-arm32-v7a.zip';
+}
+
+function resolveXrayAssetName({ platform = process.platform, arch = process.arch, armVersion } = {}) {
+    if (platform === 'win32') {
+        return `Xray-windows-${arch === 'x64' ? '64' : '32'}.zip`;
+    }
+
+    if (platform === 'darwin') {
+        return `Xray-macos-${arch === 'arm64' ? 'arm64-v8a' : '64'}.zip`;
+    }
+
+    if (platform === 'linux') {
+        return resolveLinuxXrayAssetName({ arch, armVersion });
+    }
+
+    return null;
+}
+
+module.exports = {
+    detectArmVersion,
+    resolveLinuxXrayAssetName,
+    resolveXrayAssetName
+};

--- a/tests/chromium-path.test.js
+++ b/tests/chromium-path.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveChromiumPath } = require('../src/main/chromium-path');
+
+function makeExecutable(filePath) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(filePath, 0o755);
+    return filePath;
+}
+
+test('resolveChromiumPath finds the bundled Linux Chrome binary', (t) => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'chromium-path-'));
+    t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+    const basePath = path.join(tempRoot, 'puppeteer');
+    const bundledChrome = makeExecutable(
+        path.join(basePath, 'chrome', 'linux-147.0.7727.50', 'chrome-linux64', 'chrome')
+    );
+    makeExecutable(path.join(tempRoot, 'bin', 'chromium'));
+
+    const resolved = resolveChromiumPath({
+        basePath,
+        platform: 'linux',
+        env: { PATH: path.join(tempRoot, 'bin') }
+    });
+
+    assert.equal(resolved, bundledChrome);
+});
+
+test('resolveChromiumPath falls back to PATH on Linux when no bundled browser exists', (t) => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'chromium-path-'));
+    t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+    const binDir = path.join(tempRoot, 'bin');
+    const pathChrome = makeExecutable(path.join(binDir, 'google-chrome'));
+
+    const resolved = resolveChromiumPath({
+        basePath: path.join(tempRoot, 'missing-puppeteer'),
+        platform: 'linux',
+        env: { PATH: binDir }
+    });
+
+    assert.equal(resolved, pathChrome);
+});

--- a/tests/close-behavior.test.js
+++ b/tests/close-behavior.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CLOSE_BEHAVIOR, normalizeCloseBehavior, resolveCloseBehavior } = require('../src/main/close-behavior');
+
+test('normalizeCloseBehavior defaults invalid values to tray', () => {
+    assert.equal(normalizeCloseBehavior('unexpected'), CLOSE_BEHAVIOR.TRAY);
+});
+
+test('resolveCloseBehavior keeps tray behavior when tray is available', () => {
+    const resolved = resolveCloseBehavior(CLOSE_BEHAVIOR.TRAY, { trayAvailable: true });
+    assert.equal(resolved, CLOSE_BEHAVIOR.TRAY);
+});
+
+test('resolveCloseBehavior falls back to quit when tray is unavailable', () => {
+    const resolved = resolveCloseBehavior(CLOSE_BEHAVIOR.TRAY, { trayAvailable: false });
+    assert.equal(resolved, CLOSE_BEHAVIOR.QUIT);
+});

--- a/tests/xray-assets.test.js
+++ b/tests/xray-assets.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveLinuxXrayAssetName, resolveXrayAssetName } = require('../src/main/xray-assets');
+
+test('resolveLinuxXrayAssetName maps x64 and arm64 to the correct Xray packages', () => {
+    assert.equal(resolveLinuxXrayAssetName({ arch: 'x64' }), 'Xray-linux-64.zip');
+    assert.equal(resolveLinuxXrayAssetName({ arch: 'arm64' }), 'Xray-linux-arm64-v8a.zip');
+});
+
+test('resolveLinuxXrayAssetName maps 32-bit ARM variants explicitly', () => {
+    assert.equal(resolveLinuxXrayAssetName({ arch: 'arm', armVersion: 7 }), 'Xray-linux-arm32-v7a.zip');
+    assert.equal(resolveLinuxXrayAssetName({ arch: 'arm', armVersion: 6 }), 'Xray-linux-arm32-v6.zip');
+    assert.equal(resolveLinuxXrayAssetName({ arch: 'arm', armVersion: 5 }), 'Xray-linux-arm32-v5.zip');
+});
+
+test('resolveLinuxXrayAssetName defaults unknown 32-bit ARM variants to v7a', () => {
+    assert.equal(resolveLinuxXrayAssetName({ arch: 'arm' }), 'Xray-linux-arm32-v7a.zip');
+});
+
+test('resolveXrayAssetName returns null for unsupported Linux architectures', () => {
+    assert.equal(resolveXrayAssetName({ platform: 'linux', arch: 'riscv64' }), null);
+});


### PR DESCRIPTION
 ## Summary

  This PR fixes several Linux-specific issues in the main process and startup flow:

  - fix Chromium executable discovery on Linux by checking the bundled browser, explicit environment overrides, `PATH`, and common system install locations
  - fall back to quitting the app when the system tray is unavailable, instead of hiding the window and leaving the app inaccessible
  - fix Xray package selection for Linux ARM64 and explicit 32-bit ARM variants during setup and update checks
  - update the Electron main-process build configuration so local helper modules are emitted into `out/main`, preventing startup failures like `Cannot find module './chromium-path'`

  ## Why

  The previous implementation had multiple Linux regressions:

  - Linux could incorrectly use Windows-only Chromium lookup behavior
  - tray-less desktop environments could hide the app with no recovery path
  - Linux ARM64 could request the wrong Xray asset
  ## Validation

  - `npm test`
  - `npm run build`
