### PR TITLE
feat: release v1.5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 dist/
+dist_py/
+build_py/
 release/
+__pycache__/
 userData/
 BrowserProfiles/
 _Trash_Bin/
@@ -14,3 +17,4 @@ tools/
 out/
 *.log
 *.exe
+*.geekez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 更新日志
+
+## 1.5.5
+
+- 将浏览器环境数据从单个 `profiles.json` 改为 SQLite 存储，降低高频 REST API 调用时文件被并发写坏或变成 0 字节的风险。
+- 保留旧数据迁移能力，首次启动时可从原 `profiles.json` 迁移到新的 `profiles.sqlite`。
+- 新增单环境导出 REST API：`/api/export/one`，支持按环境 ID 直接导出 `.geekez` 备份文件。
+- 修复打包后主进程找不到 `profile-store` 模块导致软件无法启动的问题。
+- 更新版本号到 `1.5.5`，并重新生成 Windows x64 portable zip 包。

--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -12,7 +12,8 @@ export default defineConfig({
           'chromium-path': resolve(__dirname, 'src/main/chromium-path.js'),
           'close-behavior': resolve(__dirname, 'src/main/close-behavior.js'),
           'xray-assets': resolve(__dirname, 'src/main/xray-assets.js'),
-          'release-check': resolve(__dirname, 'src/main/release-check.js')
+          'release-check': resolve(__dirname, 'src/main/release-check.js'),
+          'profile-store': resolve(__dirname, 'src/main/profile-store.js')
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geekez-browser",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geekez-browser",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geekez-browser",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Stealthy Anti-Detect Browser for E-Commerce",
   "main": "out/main/index.js",
   "author": "EchoHS",
@@ -25,6 +25,10 @@
       "!*.map",
       "!package-lock.json",
       "!dist",
+      "!dist_py",
+      "!build_py",
+      "!__pycache__",
+      "!*.py",
       "!_Trash_Bin",
       "!release"
     ],

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -16,6 +16,7 @@ const { getChromiumPath: resolveChromiumPathForApp } = require('./chromium-path'
 const { CLOSE_BEHAVIOR, normalizeCloseBehavior, resolveCloseBehavior } = require('./close-behavior');
 const { fetchLatestGitHubReleaseInfo } = require('./release-check');
 const { resolveXrayAssetName } = require('./xray-assets');
+const { createProfileStore } = require('./profile-store');
 const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 const initSqlJs = require('sql.js');
@@ -101,6 +102,7 @@ const TRASH_PATH = path.join(app.getPath('userData'), '_Trash_Bin');
 const PROFILES_FILE = path.join(DATA_PATH, 'profiles.json');
 const SETTINGS_FILE = path.join(DATA_PATH, 'settings.json');
 const USER_EXTENSIONS_DIR = path.join(DATA_PATH, '_extensions');
+const profileStore = createProfileStore({ dataPath: DATA_PATH, legacyProfilesFile: PROFILES_FILE });
 
 fs.ensureDirSync(DATA_PATH);
 fs.ensureDirSync(TRASH_PATH);
@@ -1438,8 +1440,90 @@ async function buildProfileFromInput(rawData, profiles, settings, existingProfil
 
 // --- Chrome 密码解密辅助函数 ---
 // 解密 Chrome 主密钥 (平台相关)
+async function createEncryptedFullBackupForProfiles(selectedProfiles, settings, password) {
+    const backupData = {
+        version: 2,
+        createdAt: Date.now(),
+        profiles: selectedProfiles.map(p => ({
+            ...p,
+            fingerprint: cleanFingerprint ? cleanFingerprint(p.fingerprint) : p.fingerprint
+        })),
+        preProxies: settings.preProxies || [],
+        subscriptions: settings.subscriptions || [],
+        browserData: {}
+    };
+
+    const filesToBackup = [
+        'Bookmarks', 'Bookmarks.bak', 'History', 'History-journal',
+        'Favicons', 'Favicons-journal', 'Preferences', 'Secure Preferences',
+        'Top Sites', 'Top Sites-journal', 'Web Data', 'Web Data-journal'
+    ];
+    const chromePath = getChromiumPath();
+
+    for (const profile of selectedProfiles) {
+        const profileDataDir = path.join(DATA_PATH, profile.id, 'browser_data');
+        const defaultDir = path.join(profileDataDir, 'Default');
+        const browserFiles = {};
+
+        if (fs.existsSync(defaultDir)) {
+            for (const fileName of filesToBackup) {
+                const filePath = path.join(defaultDir, fileName);
+                if (fs.existsSync(filePath)) {
+                    try {
+                        const content = await fs.readFile(filePath);
+                        browserFiles[fileName] = content.toString('base64');
+                    } catch (err) {
+                        console.error(`API backup file failed ${fileName}:`, err.message);
+                    }
+                }
+            }
+        }
+
+        if (Object.keys(browserFiles).length > 0) {
+            backupData.browserData[profile.id] = browserFiles;
+        }
+        if (!backupData.browserData[profile.id]) backupData.browserData[profile.id] = {};
+
+        if (fs.existsSync(profileDataDir)) {
+            let browser = null;
+            try {
+                browser = await puppeteer.launch({
+                    headless: 'new',
+                    executablePath: chromePath,
+                    userDataDir: profileDataDir,
+                    args: ['--no-first-run', '--disable-extensions', '--disable-sync', '--disable-gpu'],
+                    defaultViewport: null,
+                    ignoreDefaultArgs: ['--enable-automation'],
+                });
+                const page = (await browser.pages())[0] || await browser.newPage();
+                const client = await page.createCDPSession();
+                const { cookies } = await client.send('Network.getAllCookies');
+                backupData.browserData[profile.id]._cookies = cookies;
+            } catch (err) {
+                console.error(`API cookie export failed (${profile.id}):`, err.message);
+            } finally {
+                if (browser) {
+                    try { await browser.close(); } catch (e) { }
+                }
+            }
+        }
+
+        try {
+            const pwJsonFile = path.join(DATA_PATH, profile.id, 'passwords.json');
+            const passwords = await readEncryptedPasswords(pwJsonFile, profile.id);
+            if (passwords.length > 0) backupData.browserData[profile.id]._passwords = passwords;
+        } catch (err) {
+            console.error(`API password export failed (${profile.id}):`, err.message);
+        }
+    }
+
+    const jsonStr = JSON.stringify(backupData);
+    const compressed = await gzip(Buffer.from(jsonStr, 'utf8'));
+    return encryptData(compressed, password);
+}
+
 async function handleApiRequest(method, pathname, body, params, context = {}) {
-    let profiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
+    let profiles = await profileStore.readProfiles();
     const settings = fs.existsSync(SETTINGS_FILE) ? await fs.readJson(SETTINGS_FILE) : {};
 
     // Helper: Find profile by ID or Name
@@ -1453,7 +1537,7 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
         const fromFallback = normalizeDebugPort(fallbackPort);
         if (fromFallback) return fromFallback;
 
-        const latestProfiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE).catch(() => []) : [];
+        const latestProfiles = await profileStore.readProfiles().catch(() => []);
         const latest = Array.isArray(latestProfiles) ? latestProfiles.find(p => p.id === profileId) : null;
         return normalizeDebugPort(latest?.debugPort);
     };
@@ -1483,9 +1567,12 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
     // POST /api/profiles - Create with unique name
     if (method === 'POST' && pathname === '/api/profiles') {
         const data = parseApiBody(body);
-        const newProfile = await buildProfileFromInput(data, profiles, settings);
-        profiles.push(newProfile);
-        await fs.writeJson(PROFILES_FILE, profiles);
+        const newProfile = await profileStore.runExclusive(async (repo) => {
+            const currentProfiles = repo.readProfiles();
+            const created = await buildProfileFromInput(data, currentProfiles, settings);
+            repo.upsertProfile(created);
+            return created;
+        });
         notifyUIRefresh(); // Notify UI to refresh
         return {
             success: true,
@@ -1496,27 +1583,37 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
 
     // PUT /api/profiles/:idOrName - Edit
     if (method === 'PUT' && profileMatch) {
-        const profile = findProfile(decodeURIComponent(profileMatch[1]));
-        if (!profile) return { status: 404, data: { success: false, error: 'Profile not found' } };
-        const idx = profiles.findIndex(p => p.id === profile.id);
         const data = parseApiBody(body);
-        const otherProfiles = profiles.filter(p => p.id !== profile.id);
-        profiles[idx] = await buildProfileFromInput(data, otherProfiles, settings, profile);
-        await fs.writeJson(PROFILES_FILE, profiles);
+        const idOrName = decodeURIComponent(profileMatch[1]);
+        const updated = await profileStore.runExclusive(async (repo) => {
+            const currentProfiles = repo.readProfiles();
+            const profile = currentProfiles.find(p => p.id === idOrName || p.name === idOrName);
+            if (!profile) return null;
+            const otherProfiles = currentProfiles.filter(p => p.id !== profile.id);
+            const rebuilt = await buildProfileFromInput(data, otherProfiles, settings, profile);
+            repo.upsertProfile(rebuilt);
+            return rebuilt;
+        });
+        if (!updated) return { status: 404, data: { success: false, error: 'Profile not found' } };
         notifyUIRefresh();
         return {
             success: true,
-            profile: profiles[idx],
-            remoteDebugPort: settings.enableRemoteDebugging ? profiles[idx].debugPort : null
+            profile: updated,
+            remoteDebugPort: settings.enableRemoteDebugging ? updated.debugPort : null
         };
     }
 
     // DELETE /api/profiles/:idOrName
     if (method === 'DELETE' && profileMatch) {
-        const profile = findProfile(decodeURIComponent(profileMatch[1]));
-        if (!profile) return { status: 404, data: { success: false, error: 'Profile not found' } };
-        profiles = profiles.filter(p => p.id !== profile.id);
-        await fs.writeJson(PROFILES_FILE, profiles);
+        const idOrName = decodeURIComponent(profileMatch[1]);
+        const deletedProfile = await profileStore.runExclusive((repo) => {
+            const profile = repo.getProfile(idOrName);
+            if (!profile) return null;
+            repo.deleteProfile(profile.id);
+            return profile;
+        });
+        if (!deletedProfile) return { status: 404, data: { success: false, error: 'Profile not found' } };
+        profiles = await profileStore.readProfiles();
         notifyUIRefresh(); // Notify UI to refresh
         return { success: true, message: 'Profile deleted' };
     }
@@ -1661,6 +1758,34 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
         };
     }
 
+    // GET /api/export/one?password=xxx&id=profileId&path=D%3A%5Ccache%5Cbackup.geekez
+    if (method === 'GET' && pathname === '/api/export/one') {
+        const password = params.get('password');
+        const id = String(params.get('id') || '').trim();
+        const outputPath = String(params.get('path') || '').trim();
+
+        if (!password) return { status: 400, data: { success: false, error: 'Password required. Use ?password=yourpassword' } };
+        if (!id) return { status: 400, data: { success: false, error: 'Profile id required. Use ?id=profileId' } };
+        if (!outputPath) return { status: 400, data: { success: false, error: 'Output path required. Use ?path=D%3A%5Cbackup.geekez' } };
+
+        const profile = findProfile(id);
+        if (!profile) return { status: 404, data: { success: false, error: 'Profile not found' } };
+
+        const encrypted = await createEncryptedFullBackupForProfiles([profile], settings, password);
+        const resolvedOutputPath = path.resolve(outputPath);
+        await fs.ensureDir(path.dirname(resolvedOutputPath));
+        await fs.writeFile(resolvedOutputPath, encrypted);
+
+        return {
+            success: true,
+            filePath: resolvedOutputPath,
+            filename: path.basename(resolvedOutputPath),
+            profileId: profile.id,
+            profileName: profile.name,
+            profileCount: 1
+        };
+    }
+
     // GET /api/export/fingerprint - Export YAML fingerprints
     if (method === 'GET' && pathname === '/api/export/fingerprint') {
         const exportData = profiles.map(p => ({
@@ -1692,21 +1817,25 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
             try {
                 const yamlData = yaml.load(content);
                 if (Array.isArray(yamlData)) {
-                    let imported = 0;
-                    for (const item of yamlData) {
-                        const name = generateUniqueName(item.name || `Imported-${Date.now()}`);
-                        const newProfile = {
-                            id: uuidv4(),
-                            name,
-                            proxyStr: item.proxyStr || '',
-                            tags: item.tags || [],
-                            fingerprint: item.fingerprint || await generateFingerprint({}),
-                            createdAt: Date.now()
-                        };
-                        profiles.push(newProfile);
-                        imported++;
-                    }
-                    await fs.writeJson(PROFILES_FILE, profiles);
+                    const imported = await profileStore.runExclusive(async (repo) => {
+                        const currentProfiles = repo.readProfiles();
+                        let importedCount = 0;
+                        for (const item of yamlData) {
+                            const name = buildUniqueProfileName(currentProfiles, item.name || `Imported-${Date.now()}`);
+                            const newProfile = {
+                                id: uuidv4(),
+                                name,
+                                proxyStr: item.proxyStr || '',
+                                tags: item.tags || [],
+                                fingerprint: item.fingerprint || await generateFingerprint({}),
+                                createdAt: Date.now()
+                            };
+                            currentProfiles.push(newProfile);
+                            repo.upsertProfile(newProfile);
+                            importedCount++;
+                        }
+                        return importedCount;
+                    });
                     notifyUIRefresh(); // Notify UI to refresh
                     return { success: true, message: `Imported ${imported} profiles from YAML`, count: imported };
                 }
@@ -1721,14 +1850,18 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
                 const decompressed = await gunzip(decrypted);
                 const backupData = JSON.parse(decompressed.toString('utf8'));
 
-                let imported = 0;
-                for (const profile of backupData.profiles || []) {
-                    const name = generateUniqueName(profile.name);
-                    const newProfile = { ...profile, id: uuidv4(), name };
-                    profiles.push(newProfile);
-                    imported++;
-                }
-                await fs.writeJson(PROFILES_FILE, profiles);
+                const imported = await profileStore.runExclusive((repo) => {
+                    const currentProfiles = repo.readProfiles();
+                    let importedCount = 0;
+                    for (const profile of backupData.profiles || []) {
+                        const name = buildUniqueProfileName(currentProfiles, profile.name);
+                        const newProfile = { ...profile, id: uuidv4(), name };
+                        currentProfiles.push(newProfile);
+                        repo.upsertProfile(newProfile);
+                        importedCount++;
+                    }
+                    return importedCount;
+                });
                 notifyUIRefresh(); // Notify UI to refresh
                 return { success: true, message: `Imported ${imported} profiles from backup`, count: imported };
             } catch (decryptErr) {
@@ -1914,8 +2047,7 @@ app.on('second-instance', () => {
 });
 
 async function readAllProfilesSafe() {
-    if (!fs.existsSync(PROFILES_FILE)) return [];
-    const profiles = await fs.readJson(PROFILES_FILE).catch(() => []);
+    const profiles = await profileStore.readProfiles().catch(() => []);
     return Array.isArray(profiles) ? profiles : [];
 }
 
@@ -3317,26 +3449,31 @@ ipcMain.handle('get-profile-runtime-state', () => ({
     runningIds: Object.keys(activeProcesses),
     launchingIds: Array.from(launchingProfiles)
 }));
-ipcMain.handle('get-profiles', async () => { if (!fs.existsSync(PROFILES_FILE)) return []; return fs.readJson(PROFILES_FILE); });
+ipcMain.handle('get-profiles', async () => profileStore.readProfiles());
 ipcMain.handle('update-profile', async (event, updatedProfile) => {
-    const profiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
-    const index = profiles.findIndex(p => p.id === updatedProfile.id);
-    if (index === -1) return false;
-
     const settings = fs.existsSync(SETTINGS_FILE) ? await fs.readJson(SETTINGS_FILE) : {};
-    const others = profiles.filter((_, i) => i !== index);
-    const rebuilt = await buildProfileFromInput(updatedProfile, others, settings, profiles[index]);
-    profiles[index] = rebuilt;
-    await fs.writeJson(PROFILES_FILE, profiles);
+    const updated = await profileStore.runExclusive(async (repo) => {
+        const profiles = repo.readProfiles();
+        const index = profiles.findIndex(p => p.id === updatedProfile.id);
+        if (index === -1) return false;
+
+        const others = profiles.filter((_, i) => i !== index);
+        const rebuilt = await buildProfileFromInput(updatedProfile, others, settings, profiles[index]);
+        repo.upsertProfile(rebuilt);
+        return true;
+    });
+    if (!updated) return false;
     notifyUIRefresh();
     return true;
 });
 ipcMain.handle('save-profile', async (event, data) => {
-    const profiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
     const settings = fs.existsSync(SETTINGS_FILE) ? await fs.readJson(SETTINGS_FILE) : {};
-    const newProfile = await buildProfileFromInput(data, profiles, settings);
-    profiles.push(newProfile);
-    await fs.writeJson(PROFILES_FILE, profiles);
+    const newProfile = await profileStore.runExclusive(async (repo) => {
+        const profiles = repo.readProfiles();
+        const created = await buildProfileFromInput(data, profiles, settings);
+        repo.upsertProfile(created);
+        return created;
+    });
     notifyUIRefresh();
     return newProfile;
 });
@@ -3348,10 +3485,8 @@ ipcMain.handle('delete-profile', async (event, id) => {
         await new Promise(r => setTimeout(r, 1000));
     }
 
-    // 从 profiles.json 中删除
-    let profiles = await fs.readJson(PROFILES_FILE);
-    profiles = profiles.filter(p => p.id !== id);
-    await fs.writeJson(PROFILES_FILE, profiles);
+    // Remove from SQLite profile store first; then delete the profile directory.
+    await profileStore.deleteProfile(id);
     notifyUIRefresh();
 
     // 永久删除 profile 文件夹（带重试机制）
@@ -3656,11 +3791,15 @@ ipcMain.handle('set-data-directory', async (e, { newPath, migrate }) => {
         // 如果需要迁移数据
         if (migrate && DATA_PATH !== newPath) {
             const oldProfiles = path.join(DATA_PATH, 'profiles.json');
+            const oldProfilesDb = path.join(DATA_PATH, 'profiles.sqlite');
             const oldSettings = path.join(DATA_PATH, 'settings.json');
 
             // 迁移 profiles.json
             if (fs.existsSync(oldProfiles)) {
                 await fs.copy(oldProfiles, path.join(newPath, 'profiles.json'));
+            }
+            if (fs.existsSync(oldProfilesDb)) {
+                await fs.copy(oldProfilesDb, path.join(newPath, 'profiles.sqlite'));
             }
             // 迁移 settings.json
             if (fs.existsSync(oldSettings)) {
@@ -3669,7 +3808,8 @@ ipcMain.handle('set-data-directory', async (e, { newPath, migrate }) => {
 
             // 迁移所有环境数据目录
             const profiles = fs.existsSync(oldProfiles) ? await fs.readJson(oldProfiles) : [];
-            for (const profile of profiles) {
+            const migratedProfiles = await profileStore.readProfiles().catch(() => []);
+            for (const profile of migratedProfiles) {
                 const oldDir = path.join(DATA_PATH, profile.id);
                 const newDir = path.join(newPath, profile.id);
                 if (fs.existsSync(oldDir)) {
@@ -3806,13 +3946,13 @@ async function writeEncryptedPasswords(pwFile, passwords, profileId) {
 
 // 获取用于选择器的环境列表
 ipcMain.handle('get-export-profiles', async () => {
-    const profiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
+    const profiles = await profileStore.readProfiles();
     return profiles.map(p => ({ id: p.id, name: p.name, tags: p.tags || [] }));
 });
 
 // 导出选定环境 (精简版，不含浏览器数据)
 ipcMain.handle('export-selected-data', async (e, { type, profileIds }) => {
-    const allProfiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
+    const allProfiles = await profileStore.readProfiles();
     const settings = fs.existsSync(SETTINGS_FILE) ? await fs.readJson(SETTINGS_FILE) : { preProxies: [], subscriptions: [] };
 
     // 过滤选中的环境
@@ -3868,7 +4008,7 @@ ipcMain.handle('export-full-backup', async (e, { profileIds, password, filePath 
         }
         
         currentImportProgress = { percent: 5, message: 'Preparing Profiles...', processing: true };
-        const allProfiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
+        const allProfiles = await profileStore.readProfiles();
         const settings = fs.existsSync(SETTINGS_FILE) ? await fs.readJson(SETTINGS_FILE) : { preProxies: [], subscriptions: [] };
 
         const selectedProfiles = allProfiles
@@ -4025,14 +4165,18 @@ ipcMain.handle('import-full-backup', async (e, { filePath, password }) => {
 
         // 还原 profiles
         currentImportProgress = { percent: 40, message: 'Restoring Profiles...', processing: true };
-        const currentProfiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
-        let importedCount = 0;
-        for (const profile of backupData.profiles) {
-            const idx = currentProfiles.findIndex(cp => cp.id === profile.id);
-            if (idx > -1) { currentProfiles[idx] = profile; } else { currentProfiles.push(profile); }
-            importedCount++;
-        }
-        await fs.writeJson(PROFILES_FILE, currentProfiles);
+        const importedCount = await profileStore.runExclusive((repo) => {
+            const currentProfiles = repo.readProfiles();
+            let count = 0;
+            for (const profile of backupData.profiles || []) {
+                const idx = currentProfiles.findIndex(cp => cp.id === profile.id);
+                if (idx > -1) currentProfiles[idx] = profile;
+                else currentProfiles.push(profile);
+                count++;
+            }
+            repo.replaceProfiles(currentProfiles);
+            return count;
+        });
 
         // 还原代理和订阅
         currentImportProgress = { percent: 50, message: 'Restoring Proxies & Settings...', processing: true };
@@ -4161,16 +4305,17 @@ ipcMain.handle('import-data', async () => {
 
             if (data.profiles || data.preProxies || data.subscriptions) {
                 if (Array.isArray(data.profiles)) {
-                    const currentProfiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
-                    data.profiles.forEach(p => {
-                        const idx = currentProfiles.findIndex(cp => cp.id === p.id);
-                        if (idx > -1) currentProfiles[idx] = p;
-                        else {
-                            if (!p.id) p.id = uuidv4();
-                            currentProfiles.push(p);
-                        }
+                    await profileStore.runExclusive((repo) => {
+                        const currentProfiles = repo.readProfiles();
+                        data.profiles.forEach(p => {
+                            const profile = { ...p };
+                            if (!profile.id) profile.id = uuidv4();
+                            const idx = currentProfiles.findIndex(cp => cp.id === profile.id);
+                            if (idx > -1) currentProfiles[idx] = profile;
+                            else currentProfiles.push(profile);
+                        });
+                        repo.replaceProfiles(currentProfiles);
                     });
-                    await fs.writeJson(PROFILES_FILE, currentProfiles);
                     updated = true;
                 }
                 if (Array.isArray(data.preProxies) || Array.isArray(data.subscriptions)) {
@@ -4192,10 +4337,8 @@ ipcMain.handle('import-data', async () => {
                 }
             } else if (data.name && data.proxyStr && data.fingerprint) {
                 // 单个环境导入
-                const profiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
                 const newProfile = { ...data, id: uuidv4(), isSetup: false, createdAt: Date.now() };
-                profiles.push(newProfile);
-                await fs.writeJson(PROFILES_FILE, profiles);
+                await profileStore.upsertProfile(newProfile);
                 updated = true;
             }
             return updated;
@@ -4209,7 +4352,7 @@ ipcMain.handle('import-data', async () => {
 
 // 保留旧的 export-data 用于向后兼容 (deprecated)
 ipcMain.handle('export-data', async (e, type) => {
-    const profiles = fs.existsSync(PROFILES_FILE) ? await fs.readJson(PROFILES_FILE) : [];
+    const profiles = await profileStore.readProfiles();
     const settings = fs.existsSync(SETTINGS_FILE) ? await fs.readJson(SETTINGS_FILE) : { preProxies: [], subscriptions: [] };
 
     // 清理 fingerprint
@@ -4326,7 +4469,7 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
     }));
     const uiLang = preferredLang === 'en' ? 'en' : (settings.lang === 'en' ? 'en' : 'cn');
 
-    const profiles = await fs.readJson(PROFILES_FILE);
+    const profiles = await profileStore.readProfiles();
     const profileIndex = profiles.findIndex(p => p.id === profileId);
     const profile = profileIndex > -1 ? profiles[profileIndex] : null;
     if (!profile) throw new Error('Profile not found');
@@ -4345,7 +4488,7 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
     if (settings.enableRemoteDebugging && !normalizeDebugPort(profile.debugPort)) {
         profile.debugPort = await allocateDebugPortIfNeeded(settings, profiles, null);
         profiles[profileIndex] = profile;
-        await fs.writeJson(PROFILES_FILE, profiles);
+        await profileStore.upsertProfile(profile);
     }
 
     const useDirectNetwork = isDirectProxy(profile.proxyStr);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -235,16 +235,41 @@ function parseCliLikeArgs(rawValue) {
     const text = String(rawValue || '').trim();
     if (!text) return [];
 
-    const matches = text.match(/"[^"]*"|'[^']*'|[^\s]+/g) || [];
-    return matches
-        .map((part) => String(part || '').trim())
-        .map((part) => {
-            if ((part.startsWith('"') && part.endsWith('"')) || (part.startsWith("'") && part.endsWith("'"))) {
-                return part.slice(1, -1);
+    const args = [];
+    let current = '';
+    let quote = '';
+
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        const next = text[i + 1];
+
+        if (quote) {
+            if (ch === quote) {
+                quote = '';
+            } else {
+                current += ch;
             }
-            return part;
-        })
-        .filter(Boolean);
+            continue;
+        }
+
+        if (ch === '"' || ch === "'") {
+            quote = ch;
+            continue;
+        }
+
+        if (/\s/.test(ch) && next === '-' && text[i + 2] === '-') {
+            const normalized = current.trim();
+            if (normalized) args.push(normalized);
+            current = '';
+            continue;
+        }
+
+        current += ch;
+    }
+
+    const normalized = current.trim();
+    if (normalized) args.push(normalized);
+    return args;
 }
 
 function normalizeLaunchOverrideArgs(input) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1606,15 +1606,10 @@ async function handleApiRequest(method, pathname, body, params, context = {}) {
     // DELETE /api/profiles/:idOrName
     if (method === 'DELETE' && profileMatch) {
         const idOrName = decodeURIComponent(profileMatch[1]);
-        const deletedProfile = await profileStore.runExclusive((repo) => {
-            const profile = repo.getProfile(idOrName);
-            if (!profile) return null;
-            repo.deleteProfile(profile.id);
-            return profile;
-        });
+        const deletedProfile = await profileStore.runExclusive((repo) => repo.getProfile(idOrName));
         if (!deletedProfile) return { status: 404, data: { success: false, error: 'Profile not found' } };
+        await deleteProfileCompletely(deletedProfile.id);
         profiles = await profileStore.readProfiles();
-        notifyUIRefresh(); // Notify UI to refresh
         return { success: true, message: 'Profile deleted' };
     }
 
@@ -2450,6 +2445,48 @@ function notifyUIRefresh() {
         } catch (e) { }
     });
     refreshTrayMenu().catch(() => { });
+}
+
+async function deleteProfileCompletely(id) {
+    if (activeProcesses[id]) {
+        await stopRunningProfile(id, { refreshMenu: false });
+        await new Promise(r => setTimeout(r, 1000));
+    }
+
+    await profileStore.deleteProfile(id);
+    notifyUIRefresh();
+
+    const profileDir = path.join(DATA_PATH, id);
+    let deleted = false;
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            if (fs.existsSync(profileDir)) {
+                await fs.remove(profileDir);
+                console.log(`Deleted profile folder: ${profileDir}`);
+            }
+            deleted = true;
+            break;
+        } catch (err) {
+            console.error(`Delete attempt ${attempt} failed:`, err.message);
+            if (attempt < 3) {
+                await new Promise(r => setTimeout(r, 500 * attempt));
+            }
+        }
+    }
+
+    if (!deleted && fs.existsSync(profileDir)) {
+        console.warn(`Failed to delete, moving to trash: ${profileDir}`);
+        const trashDest = path.join(TRASH_PATH, `${id}_${Date.now()}`);
+        try {
+            await fs.move(profileDir, trashDest);
+            console.log(`Moved to trash: ${trashDest}`);
+        } catch (err) {
+            console.error('Failed to move to trash:', err);
+        }
+    }
+
+    return true;
 }
 
 async function generateExtension(profilePath, fingerprint, profileName, watermarkStyle, profileId) {
@@ -3478,56 +3515,7 @@ ipcMain.handle('save-profile', async (event, data) => {
     return newProfile;
 });
 ipcMain.handle('delete-profile', async (event, id) => {
-    // 关闭正在运行的进程
-    if (activeProcesses[id]) {
-        await stopRunningProfile(id, { refreshMenu: false });
-        // Windows 需要更长的等待时间让文件释放
-        await new Promise(r => setTimeout(r, 1000));
-    }
-
-    // Remove from SQLite profile store first; then delete the profile directory.
-    await profileStore.deleteProfile(id);
-    notifyUIRefresh();
-
-    // 永久删除 profile 文件夹（带重试机制）
-    const profileDir = path.join(DATA_PATH, id);
-    let deleted = false;
-
-    // 尝试删除 3 次
-    for (let attempt = 1; attempt <= 3; attempt++) {
-        try {
-            if (fs.existsSync(profileDir)) {
-                // 使用 fs-extra 的 remove，它会递归删除
-                await fs.remove(profileDir);
-                console.log(`Deleted profile folder: ${profileDir}`);
-                deleted = true;
-                break;
-            } else {
-                deleted = true;
-                break;
-            }
-        } catch (err) {
-            console.error(`Delete attempt ${attempt} failed:`, err.message);
-            if (attempt < 3) {
-                // 等待后重试
-                await new Promise(r => setTimeout(r, 500 * attempt));
-            }
-        }
-    }
-
-    // 如果删除失败，移到回收站作为后备方案
-    if (!deleted && fs.existsSync(profileDir)) {
-        console.warn(`Failed to delete, moving to trash: ${profileDir}`);
-        const trashDest = path.join(TRASH_PATH, `${id}_${Date.now()}`);
-        try {
-            await fs.move(profileDir, trashDest);
-            console.log(`Moved to trash: ${trashDest}`);
-        } catch (err) {
-            console.error(`Failed to move to trash:`, err);
-        }
-    }
-
-    return true;
+    return deleteProfileCompletely(id);
 });
 ipcMain.handle('get-settings', async () => {
     if (!fs.existsSync(SETTINGS_FILE)) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -294,6 +294,33 @@ function normalizeLaunchOverrideArgs(input) {
     });
 }
 
+function getLaunchArgValue(args, name) {
+    const normalizedName = String(name || '').replace(/^-+/, '');
+    const equalsPrefix = `--${normalizedName}=`;
+    const spacePrefix = `--${normalizedName} `;
+
+    for (let i = args.length - 1; i >= 0; i--) {
+        const arg = String(args[i] || '').trim();
+        if (arg.startsWith(equalsPrefix)) return arg.slice(equalsPrefix.length).trim();
+        if (arg.startsWith(spacePrefix)) return arg.slice(spacePrefix.length).trim();
+    }
+
+    return '';
+}
+
+function createRuntimeFingerprint(baseFingerprint, launchArgsOverride = []) {
+    const fingerprint = { ...(baseFingerprint || {}) };
+    const userAgentOverride = getLaunchArgValue(launchArgsOverride, 'user-agent');
+
+    if (userAgentOverride) {
+        fingerprint.userAgent = userAgentOverride;
+        delete fingerprint.userAgentMetadata;
+        delete fingerprint.secChUa;
+    }
+
+    return fingerprint;
+}
+
 function resolveApiLaunchOverrideArgs(params) {
     const rawArgs = params?.getAll?.('args') || [];
     return normalizeLaunchOverrideArgs(rawArgs);
@@ -4734,10 +4761,11 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
             profile.fingerprint.language = 'auto';
             profile.fingerprint.languages = [];
         }
+        const runtimeFingerprint = createRuntimeFingerprint(profile.fingerprint, launchArgsOverride);
 
         // 1. 生成 GeekEZ Guard 扩展（使用传递的水印样式）
         const style = watermarkStyle || 'enhanced'; // 默认使用增强水印
-        const extPath = await generateExtension(profileDir, profile.fingerprint, profile.name, style, profileId);
+        const extPath = await generateExtension(profileDir, runtimeFingerprint, profile.name, style, profileId);
 
         // 2. 获取当前环境需要加载的用户扩展
         updateLaunchProgress(
@@ -4801,8 +4829,8 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
             launchArgs.unshift('--no-proxy-server');
         }
 
-        if (profile.fingerprint?.userAgent) {
-            launchArgs.push(`--user-agent=${profile.fingerprint.userAgent}`);
+        if (runtimeFingerprint?.userAgent && !getLaunchArgValue(launchArgsOverride, 'user-agent')) {
+            launchArgs.push(`--user-agent=${runtimeFingerprint.userAgent}`);
         }
         if (hasLanguageOverride) {
             launchArgs.push(`--lang=${targetLang}`);
@@ -4891,7 +4919,7 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
         const acceptLanguageHeader = shortLang && shortLang !== targetLang
             ? `${targetLang},${shortLang};q=0.9`
             : targetLang;
-        const fingerprintInjectScript = getInjectScript(profile.fingerprint, profile.name, style);
+        const fingerprintInjectScript = getInjectScript(runtimeFingerprint, profile.name, style);
         const watermarkInjectScript = getWatermarkScript(profile.name, style);
         const enableWebglOverride = !!(
             profile.fingerprint?.webglProfile !== 'none' &&
@@ -5048,18 +5076,18 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
                     } catch (e) { }
                 }
 
-                if (profile.fingerprint?.userAgent) {
+                if (runtimeFingerprint?.userAgent) {
                     const payload = {
-                        userAgent: profile.fingerprint.userAgent
+                        userAgent: runtimeFingerprint.userAgent
                     };
                     if (hasLanguageOverride) {
                         payload.acceptLanguage = targetLang;
                     }
-                    if (profile.fingerprint?.platform) {
-                        payload.platform = profile.fingerprint.platform;
+                    if (runtimeFingerprint?.platform) {
+                        payload.platform = runtimeFingerprint.platform;
                     }
 
-                    const metadata = profile.fingerprint?.userAgentMetadata;
+                    const metadata = runtimeFingerprint?.userAgentMetadata;
                     if (metadata && typeof metadata === 'object') {
                         const md = {
                             mobile: !!metadata.mobile

--- a/src/main/profile-store.js
+++ b/src/main/profile-store.js
@@ -1,0 +1,283 @@
+const path = require('path');
+const fs = require('fs-extra');
+const initSqlJs = require('sql.js');
+
+function createProfileStore({ dataPath, legacyProfilesFile }) {
+    const dbPath = path.join(dataPath, 'profiles.sqlite');
+    let dbPromise = null;
+    let queue = Promise.resolve();
+
+    function enqueue(task) {
+        const run = queue.then(task, task);
+        queue = run.catch(() => { });
+        return run;
+    }
+
+    function resolveSqlWasmPath(file) {
+        try {
+            const sqlJsEntry = require.resolve('sql.js');
+            const candidate = path.join(path.dirname(sqlJsEntry), file);
+            if (fs.existsSync(candidate)) return candidate;
+        } catch (e) { }
+
+        try {
+            const candidate = require.resolve(`sql.js/dist/${file}`);
+            if (fs.existsSync(candidate)) return candidate;
+        } catch (e) { }
+
+        return file;
+    }
+
+    async function loadSql() {
+        return initSqlJs({
+            locateFile: (file) => resolveSqlWasmPath(file)
+        });
+    }
+
+    function createSchema(db) {
+        db.run(`
+            CREATE TABLE IF NOT EXISTS profiles (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                data TEXT NOT NULL,
+                order_index INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_profiles_name ON profiles(name);
+            CREATE INDEX IF NOT EXISTS idx_profiles_order ON profiles(order_index, created_at, id);
+            PRAGMA user_version = 1;
+        `);
+    }
+
+    function readProfilesFromDb(db) {
+        const stmt = db.prepare(`
+            SELECT data
+            FROM profiles
+            ORDER BY order_index ASC, created_at ASC, id ASC
+        `);
+        const profiles = [];
+        try {
+            while (stmt.step()) {
+                const row = stmt.getAsObject();
+                try {
+                    const profile = JSON.parse(row.data);
+                    if (profile && profile.id) profiles.push(profile);
+                } catch (e) {
+                    console.error('Failed to parse profile row:', e.message);
+                }
+            }
+        } finally {
+            stmt.free();
+        }
+        return profiles;
+    }
+
+    function getProfileFromDb(db, idOrName) {
+        const stmt = db.prepare('SELECT data FROM profiles WHERE id = ? OR name = ? LIMIT 1');
+        try {
+            stmt.bind([idOrName, idOrName]);
+            if (!stmt.step()) return null;
+            const row = stmt.getAsObject();
+            return JSON.parse(row.data);
+        } finally {
+            stmt.free();
+        }
+    }
+
+    function getMaxOrderIndex(db) {
+        const result = db.exec('SELECT COALESCE(MAX(order_index), -1) AS max_order FROM profiles');
+        if (!result.length || !result[0].values.length) return -1;
+        return Number(result[0].values[0][0]) || -1;
+    }
+
+    function getExistingOrderIndex(db, id) {
+        const stmt = db.prepare('SELECT order_index FROM profiles WHERE id = ? LIMIT 1');
+        try {
+            stmt.bind([id]);
+            if (!stmt.step()) return null;
+            const row = stmt.getAsObject();
+            return Number(row.order_index);
+        } finally {
+            stmt.free();
+        }
+    }
+
+    function upsertProfileInDb(db, profile, orderIndex = null) {
+        if (!profile || !profile.id) {
+            throw new Error('Cannot save profile without id');
+        }
+
+        const existingOrder = getExistingOrderIndex(db, profile.id);
+        const finalOrder = Number.isFinite(orderIndex)
+            ? orderIndex
+            : (existingOrder !== null ? existingOrder : getMaxOrderIndex(db) + 1);
+        const createdAt = Number(profile.createdAt || profile.created_at || 0) || Date.now();
+        const updatedAt = Date.now();
+        const data = JSON.stringify(profile);
+
+        db.run(`
+            INSERT INTO profiles (id, name, data, order_index, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                data = excluded.data,
+                order_index = excluded.order_index,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at
+        `, [
+            String(profile.id),
+            String(profile.name || profile.id),
+            data,
+            finalOrder,
+            createdAt,
+            updatedAt
+        ]);
+    }
+
+    function replaceProfilesInDb(db, profiles) {
+        db.run('DELETE FROM profiles');
+        profiles.forEach((profile, index) => {
+            upsertProfileInDb(db, profile, index);
+        });
+    }
+
+    async function flushDb(db) {
+        await fs.ensureDir(dataPath);
+        const tmpPath = `${dbPath}.${process.pid}.${Date.now()}.tmp`;
+        const bytes = Buffer.from(db.export());
+        await fs.writeFile(tmpPath, bytes);
+        await fs.rename(tmpPath, dbPath);
+    }
+
+    async function migrateLegacyProfiles(db) {
+        if (!legacyProfilesFile || !fs.existsSync(legacyProfilesFile)) return false;
+
+        const stat = await fs.stat(legacyProfilesFile).catch(() => null);
+        if (!stat || stat.size === 0) return false;
+
+        const existing = readProfilesFromDb(db);
+        if (existing.length > 0) return false;
+
+        const legacyProfiles = await fs.readJson(legacyProfilesFile).catch((err) => {
+            console.error('Failed to read legacy profiles.json:', err.message);
+            return [];
+        });
+        if (!Array.isArray(legacyProfiles) || legacyProfiles.length === 0) return false;
+
+        replaceProfilesInDb(db, legacyProfiles.filter(profile => profile && profile.id));
+        return true;
+    }
+
+    async function initDb() {
+        if (dbPromise) return dbPromise;
+
+        dbPromise = (async () => {
+            await fs.ensureDir(dataPath);
+            const SQL = await loadSql();
+            let db;
+            if (fs.existsSync(dbPath)) {
+                const bytes = await fs.readFile(dbPath);
+                db = new SQL.Database(bytes);
+            } else {
+                db = new SQL.Database();
+            }
+
+            createSchema(db);
+            const migrated = await migrateLegacyProfiles(db);
+            if (!fs.existsSync(dbPath) || migrated) {
+                await flushDb(db);
+            }
+            return db;
+        })();
+
+        return dbPromise;
+    }
+
+    function createRepo(db) {
+        let changed = false;
+        return {
+            readProfiles() {
+                return readProfilesFromDb(db);
+            },
+            getProfile(idOrName) {
+                return getProfileFromDb(db, idOrName);
+            },
+            upsertProfile(profile, orderIndex = null) {
+                upsertProfileInDb(db, profile, orderIndex);
+                changed = true;
+            },
+            replaceProfiles(profiles) {
+                replaceProfilesInDb(db, profiles);
+                changed = true;
+            },
+            deleteProfile(id) {
+                db.run('DELETE FROM profiles WHERE id = ?', [id]);
+                changed = true;
+            },
+            get changed() {
+                return changed;
+            }
+        };
+    }
+
+    async function runExclusive(task) {
+        return enqueue(async () => {
+            const db = await initDb();
+            const repo = createRepo(db);
+            db.run('BEGIN TRANSACTION');
+            try {
+                const result = await task(repo);
+                db.run('COMMIT');
+                if (repo.changed) await flushDb(db);
+                return result;
+            } catch (err) {
+                try { db.run('ROLLBACK'); } catch (e) { }
+                throw err;
+            }
+        });
+    }
+
+    async function readProfiles() {
+        return runExclusive((repo) => repo.readProfiles());
+    }
+
+    async function getProfile(idOrName) {
+        return runExclusive((repo) => repo.getProfile(idOrName));
+    }
+
+    async function upsertProfile(profile) {
+        return runExclusive((repo) => {
+            repo.upsertProfile(profile);
+            return profile;
+        });
+    }
+
+    async function replaceProfiles(profiles) {
+        return runExclusive((repo) => {
+            repo.replaceProfiles(profiles);
+            return profiles;
+        });
+    }
+
+    async function deleteProfile(id) {
+        return runExclusive((repo) => {
+            repo.deleteProfile(id);
+            return true;
+        });
+    }
+
+    return {
+        dbPath,
+        readProfiles,
+        getProfile,
+        upsertProfile,
+        replaceProfiles,
+        deleteProfile,
+        runExclusive
+    };
+}
+
+module.exports = {
+    createProfileStore
+};


### PR DESCRIPTION
## 更新内容

- 将环境数据从 `profiles.json` 改为 SQLite 存储，降低高频 REST API 调用时并发写坏文件的风险。
- 支持首次启动时从旧 `profiles.json` 自动迁移到 `profiles.sqlite`。
- 新增单环境导出接口 `/api/export/one`，可按环境 ID 直接导出 `.geekez` 备份文件。
- 修复 `DELETE /api/profiles/:idOrName` 只删除列表、不删除浏览器环境文件夹的问题。
- 修复 REST API 启动参数 `args` 中带空格的值被截断的问题。
- 修复 API `args` 传入 `--user-agent=...` 后被指纹注入和 CDP UA 覆盖逻辑覆盖的问题。
- 修复打包后主进程找不到 `profile-store` 模块导致无法启动的问题。
- 更新版本号到 `1.5.5`。

## 验证

- `npm run build`