### PR TITLE
fix: widen proxy readiness probe timeouts to avoid false launch failures

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3629,10 +3629,10 @@ async function startPreProxyHealthCheck(url) {
 }
 
 async function waitForProxyChainReady(socksPort, processRef = null, options = {}) {
-    const fastReadyTimeoutMs = Number.isFinite(options.fastReadyTimeoutMs) ? options.fastReadyTimeoutMs : 2600;
-    const fastProbeTimeoutMs = Number.isFinite(options.fastProbeTimeoutMs) ? options.fastProbeTimeoutMs : 1000;
-    const slowReadyTimeoutMs = Number.isFinite(options.slowReadyTimeoutMs) ? options.slowReadyTimeoutMs : 7000;
-    const slowProbeTimeoutMs = Number.isFinite(options.slowProbeTimeoutMs) ? options.slowProbeTimeoutMs : 2200;
+    const fastReadyTimeoutMs = Number.isFinite(options.fastReadyTimeoutMs) ? options.fastReadyTimeoutMs : 3000;
+    const fastProbeTimeoutMs = Number.isFinite(options.fastProbeTimeoutMs) ? options.fastProbeTimeoutMs : 2000;
+    const slowReadyTimeoutMs = Number.isFinite(options.slowReadyTimeoutMs) ? options.slowReadyTimeoutMs : 8000;
+    const slowProbeTimeoutMs = Number.isFinite(options.slowProbeTimeoutMs) ? options.slowProbeTimeoutMs : 4500;
     const targets = Array.isArray(options.targets) ? options.targets : null;
 
     const fastResult = await waitForSocksProxyUsable(
@@ -5227,16 +5227,16 @@ const launchProfileHandler = async (event, profileId, watermarkStyle, preferredL
                     xrayProcess,
                     activePreProxy?.url
                         ? {
-                            fastReadyTimeoutMs: 2600,
-                            fastProbeTimeoutMs: 1000,
-                            slowReadyTimeoutMs: 4200,
-                            slowProbeTimeoutMs: 1800
+                            fastReadyTimeoutMs: 3000,
+                            fastProbeTimeoutMs: 2000,
+                            slowReadyTimeoutMs: 9000,
+                            slowProbeTimeoutMs: 4500
                         }
                         : {
-                            fastReadyTimeoutMs: 2200,
-                            fastProbeTimeoutMs: 900,
-                            slowReadyTimeoutMs: 2600,
-                            slowProbeTimeoutMs: 1400
+                            fastReadyTimeoutMs: 3000,
+                            fastProbeTimeoutMs: 2000,
+                            slowReadyTimeoutMs: 8000,
+                            slowProbeTimeoutMs: 4500
                         }
                 )
             );


### PR DESCRIPTION
## Problem

After launching a profile, the app probes `www.gstatic.com` / `cp.cloudflare.com` / `www.google.com` `generate_204` through the freshly started Xray SOCKS port and treats a timeout as **proxy failed to start** (`代理启动失败，请检查代理是否可用`).

The probe budget is too aggressive for cold starts:

| phase | per-probe | overall |
|-------|-----------|---------|
| fast  | 900 ms    | 2200 ms |
| slow  | 1400 ms   | 2600 ms |

On the **first** request after launch, the proxy chain still has to establish the upstream connection and finish a TLS handshake. Measured against a healthy node, that first `generate_204` regularly takes **1.5–4 s** (subsequent requests drop to 0.3–0.9 s). So a perfectly working node reports "proxy failed to start" even though Xray has started and is already forwarding traffic (`[Warning] core: Xray 26.3.27 started` followed by normal `accepted tcp:...` lines in `xray_run.log`).

## Fix

Widen the per-probe and overall readiness timeouts so a single ~4 s cold-start handshake no longer trips a false failure:

| phase | per-probe | overall |
|-------|-----------|---------|
| fast  | 2000 ms   | 3000 ms |
| slow  | 4500 ms   | 8000–9000 ms |

Defaults in `waitForProxyChainReady()` and the explicit values at the launch call site are both updated.

## Why this is safe

Hard failures (`ECONNREFUSED`, `ECONNRESET`, `ENETUNREACH`, `HTTP 4xx/5xx`, TLS alerts, …) still short-circuit immediately via `HARD_PROXY_PROBE_PATTERNS` / `isWarmupLikeProbeMessage`, so genuinely dead nodes are **not** slowed down by the larger timeouts. Only warmup-like timeouts get the extra budget.

## Verification

Reproduced the false failure with a healthy SS node whose `generate_204` latency oscillated between 0.4 s and 4 s; the old 900/1400 ms per-probe window failed intermittently on the first (cold) probe, while the node returned HTTP 204 and served real traffic (verified egress IP) once warmed up.